### PR TITLE
Add Support OpenStack API V1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skipper-openstack",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": {
     "pkgcloud": "git+https://github.com/IBM-Bluemix/pkgcloud.git#fix-openstack-auth",
     "stream": "0.0.2",


### PR DESCRIPTION
Bluemix uses Swift API V2 for and SoftLayer uses V1. Luckily, `pkgcloud`, the dependency that's doing the heavy lifting for authentication has support for V1 and V2. However, some modification need to be made to Skipper-Openstack so that an app can indicate that a set of credentials are formatted for V1 or V2. This PR adds that functionality by expecting an integer as an argument along with credentials.

To demonstrate the functionality of this new capability, I have forked and created two copies of the `node-file-upload-swift` app, one that uses my new version of Skipper-Openstack to authenticate with Bluemix Object Storage [node-file-upload-swift](https://github.com/ahadik/node-file-upload-swift) and one that that uses this new version of Skipper-Openstack to authenticate with SoftLayer Object Storage [node-file-upload-swift-softlayer](https://github.com/ahadik/node-file-upload-swift-softlayer).

I will shortly be submitting the Bluemix version of this app as a PR to the original node app from a branch of the SoftLayer app fork.
